### PR TITLE
Create requirements.txt to help users know which packages are needed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+jsontree
+asttokens


### PR DESCRIPTION
These are the packages that are not in base python for python2.7.

Run the following command to get the packages needed for pythonparser to work:
`pip install -r requirements.txt`